### PR TITLE
Add exception handling + docs for bad import order

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,7 +31,7 @@ jobs:
         poetry run black . --check
     - name: Analyzing code with isort
       run: |
-        poetry run isort . --check-only
+        poetry run isort . --check-only --skip docs
 
   test:
     strategy:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ Your template should extend `admin/base.html` or `base_custom_admin.html` templa
 {% endblock %}
 ```
 
+### Important: Custom Views Must Be Registered Before Admin URLs are Loaded
+
+Be sure to import the files where your views are stored prior to loading your root url conf. For example:
+
+```python
+# project/urls.py
+from django.contrib import admin
+
+# importing view before url_patterns ensures it's registered!
+from some_app.views import YourCustomView 
+
+url_patterns = [
+   path("admin/", admin.site.urls),
+   ...
+]
+```
+
 ## Configurable Settings
 
 - `CUSTOM_ADMIN_DEFAULT_APP_LABEL`: set to override the default app_label (default: `django_custom_admin_pages`)

--- a/django_custom_admin_pages/admin.py
+++ b/django_custom_admin_pages/admin.py
@@ -154,9 +154,11 @@ class CustomAdminSite(admin.AdminSite):
         try:
             url = reverse(f"{self.name}:{view.route_name}")
         except NoReverseMatch as e:
-            message = f"""Cannot find CustomAdminView: {view.view_name}. This is most likely because 
-the root url conf was loaded before the view was registered. Try importing the view at the top of your
-root url conf or placing the registration above url_patterns."""
+            message = (
+                f"Cannot find CustomAdminView: {view.view_name}. This is most likely because the "
+                + "root url conf was loaded before the view was registered. Try importing the view at "
+                + "the top of your root url conf or placing the registration above url_patterns."
+            )
             raise CustomAdminImportException(message) from e
         name = view.view_name
         return {

--- a/django_custom_admin_pages/admin.py
+++ b/django_custom_admin_pages/admin.py
@@ -11,8 +11,8 @@ from django.contrib.admin.apps import AdminConfig
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import NoReverseMatch, include, path, reverse
 from django.views import View
-from django_custom_admin_pages.exceptions import CustomAdminImportException
 
+from django_custom_admin_pages.exceptions import CustomAdminImportException
 from django_custom_admin_pages.urls import add_view_to_conf
 
 if TYPE_CHECKING:

--- a/django_custom_admin_pages/admin.py
+++ b/django_custom_admin_pages/admin.py
@@ -9,8 +9,9 @@ from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.apps import AdminConfig
 from django.core.exceptions import ImproperlyConfigured
-from django.urls import include, path, reverse
+from django.urls import NoReverseMatch, include, path, reverse
 from django.views import View
+from django_custom_admin_pages.exceptions import CustomAdminImportException
 
 from django_custom_admin_pages.urls import add_view_to_conf
 
@@ -150,7 +151,13 @@ class CustomAdminSite(admin.AdminSite):
         """
         Creates dict for custom admin view for use in app_list[models]
         """
-        url = reverse(f"{self.name}:{view.route_name}")
+        try:
+            url = reverse(f"{self.name}:{view.route_name}")
+        except NoReverseMatch as e:
+            message = f"""Cannot find CustomAdminView: {view.view_name}. This is most likely because 
+the root url conf was loaded before the view was registered. Try importing the view at the top of your
+root url conf or placing the registration above url_patterns."""
+            raise CustomAdminImportException(message) from e
         name = view.view_name
         return {
             "name": name,

--- a/django_custom_admin_pages/exceptions.py
+++ b/django_custom_admin_pages/exceptions.py
@@ -1,0 +1,2 @@
+class CustomAdminImportException(Exception):
+    pass

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -46,8 +46,38 @@ To create a new custom admin view:
 5. *Optional*: Set the view class attribute ``app_label`` to the app you'd like the admin view to display in. This must match a label in ``settings.INSTALLED_APPS``. This will default to a new app called `django_custom_admin_pages` if left unset.
 6. *Optional*: Set the view class attribute ``route_name`` to manually override the automatically generated route_name in ``urlpatterns``.
 
+Registering Views
+-----------------
 
-See ``example_view.py`` for more details. (It only routes in local dev)
+After you create a view, you can register it like you would a ``ModelAdmin``:
+
+.. code-block:: python
+   ### Important: Custom Views Must Be Registered Before Admin URLs are Loaded
+
+   from django.contrib import admin
+
+   admin.site.register_view(MyCustomAdminView)
+
+
+.. warning::
+   Be sure to register your views in a file that's imported before your root url conf! Or import all your views in 
+   the root url conf above ``url_patterns``
+
+
+For example:
+
+.. code-block:: python
+   # project/urls.py
+   from django.contrib import admin
+
+   # importing view before url_patterns ensures it's registered!
+   from some_app.views import YourCustomView 
+
+   url_patterns = [
+      path("admin/", admin.site.urls),
+      ...
+   ]
+
 
 Example TemplateView
 ***********************

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -49,9 +49,10 @@ To create a new custom admin view:
 Registering Views
 -----------------
 
-After you create a view, you can register it like you would a ``ModelAdmin``.
+After you create a view, you can register it like you would a ``ModelAdmin``:
 
 .. code-block:: python
+
    ### Important: Custom Views Must Be Registered Before Admin URLs are Loaded
 
    from django.contrib import admin
@@ -64,9 +65,10 @@ After you create a view, you can register it like you would a ``ModelAdmin``.
    the root url conf above ``url_patterns``
 
 
-e.g.
+For example:
 
 .. code-block:: python
+
    # project/urls.py
    from django.contrib import admin
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -49,7 +49,7 @@ To create a new custom admin view:
 Registering Views
 -----------------
 
-After you create a view, you can register it like you would a ``ModelAdmin``:
+After you create a view, you can register it like you would a ``ModelAdmin``.
 
 .. code-block:: python
    ### Important: Custom Views Must Be Registered Before Admin URLs are Loaded
@@ -64,7 +64,7 @@ After you create a view, you can register it like you would a ``ModelAdmin``:
    the root url conf above ``url_patterns``
 
 
-For example:
+e.g.
 
 .. code-block:: python
    # project/urls.py


### PR DESCRIPTION
Noticed that if you don't register views prior to registering admin urls, it causes error when loading the admin page.

Adds docs and a more descriptive error message. Will look into making this import order not matter later. 