### PR TITLE
Fix app_label validation

### DIFF
--- a/django_custom_admin_pages/admin.py
+++ b/django_custom_admin_pages/admin.py
@@ -108,7 +108,7 @@ class CustomAdminSite(admin.AdminSite):
                 )
 
             if app_label := getattr(view, "app_label", None):
-                if not app_label in get_installed_apps():
+                if app_label not in apps.app_configs:
                     raise ImproperlyConfigured(
                         f"Your view {view.view_name} has an invalid app_label: {app_label}. App label must be in settings.INSTALLED_APPS"
                     )


### PR DESCRIPTION
The name is not always equal to the label. So for any app configured this way this check would fail incorrectly.

I've switched the check to check the label instead of the name here.

---

Ran into this issue while trying to add a custom view for the `django_tasks.backends.database` app. Which has the label `django_tasks_database`. Setting `django_tasks_database` as the view's app label caused this check to fail. And setting `django_tasks.backends.database` as the view's app label makes the check pass, but the registering fail since this was not a valid label:

```
  File /backend/.venv/lib/python3.13/site-packages/django_custom_admin_pages/admin.py", line 221, in get_app_list
    app_config = apps.get_app_config(view_app_label)
  File /backend/.venv/lib/python3.13/site-packages/django/apps/registry.py", line 165, in get_app_config
    raise LookupError(message)
LookupError: No installed app with label 'django_tasks.backends.database'. Did you mean 'django_tasks_database'?
```

Upsteam app config: https://github.com/RealOrangeOne/django-tasks/blob/fbeca7b2aa4bfb499f68a7adf31f40cac39b78cf/django_tasks/backends/database/apps.py#L4-L10